### PR TITLE
More logging, less exception throwing

### DIFF
--- a/lib/entrypoint.sh
+++ b/lib/entrypoint.sh
@@ -7,4 +7,6 @@ gem install rubocop-rspec -v 1.38.1
 gem install rubocop-performance -v 1.5.2
 gem install rubocop-rails -v 2.4.2
 
+cat ~/files.json
+
 ruby /action/lib/index.rb

--- a/lib/entrypoint.sh
+++ b/lib/entrypoint.sh
@@ -7,7 +7,4 @@ gem install rubocop-rspec -v 1.38.1
 gem install rubocop-performance -v 1.5.2
 gem install rubocop-rails -v 2.4.2
 
-echo "HELLO ARE WE PULLING THIS IN"
-cat /action/lib/index.rb
-
 ruby /action/lib/index.rb

--- a/lib/entrypoint.sh
+++ b/lib/entrypoint.sh
@@ -7,4 +7,7 @@ gem install rubocop-rspec -v 1.38.1
 gem install rubocop-performance -v 1.5.2
 gem install rubocop-rails -v 2.4.2
 
+echo "HELLO ARE WE PULLING THIS IN"
+cat /action/lib/index.rb
+
 ruby /action/lib/index.rb

--- a/lib/entrypoint.sh
+++ b/lib/entrypoint.sh
@@ -7,6 +7,4 @@ gem install rubocop-rspec -v 1.38.1
 gem install rubocop-performance -v 1.5.2
 gem install rubocop-rails -v 2.4.2
 
-cat ~/files.json
-
 ruby /action/lib/index.rb

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -131,17 +131,17 @@ end
 
 def run
   puts "\nStarting Rubocop..."
-  puts "CHANGED FILES: #{ENV['CHANGED_FILES']}"
-  id = create_check
-  begin
-    results = run_rubocop
-    conclusion = results['conclusion']
-    output = results['output']
+  puts "CHANGED FILES of commit: #{ENV['CHANGED_FILES']}"
 
-    update_check(id, conclusion, output)
-    update_check(id, 'failure', nil) if conclusion == 'failure'
-  rescue GithubAPIError
-  end
+  id = create_check
+  results = run_rubocop
+  conclusion = results['conclusion']
+  output = results['output']
+
+  puts "Results:\n\n#{output.inspect}"
+
+  update_check(id, conclusion, output)
+  update_check(id, 'failure', nil) if conclusion == 'failure'
 end
 
 run

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -82,8 +82,10 @@ end
 def run_rubocop
   annotations = []
   errors = nil
+  changed_files = JSON.parse(ENV['CHANGED_FILES']).join(" ")
   Dir.chdir(@GITHUB_WORKSPACE) do
-    errors = JSON.parse(`rubocop --format json`)
+    # only run rubocop on changes files
+    errors = JSON.parse(`rubocop --format json #{changed_files}`)
   end
   conclusion = 'success'
   count = 0

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -123,6 +123,7 @@ end
 
 def run
   puts "Running Rubocop"
+  puts "CHANGED FILES: #{ENV['CHANGED_FILES']}"
   id = create_check
   begin
     results = run_rubocop

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -91,7 +91,8 @@ def run_rubocop
   #changed_files = `git diff --name-only #{merge_base}`.split("\n")
 
   # changed files of commit
-  changed_files = `git diff --name-only HEAD HEAD~1`.split("\n")
+  current_commit,previous_commit = `git log -n 2 --format=format:%H`.split("\n")
+  changed_files = `git diff --name-only #{current_commit}..#{previous_commit}`.split("\n")
   changed_files.delete_if{ |filename| filename[-3..-1] != '.rb' }
   
 

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -88,7 +88,12 @@ def run_rubocop
   merge_base = `git merge-base --fork-point origin/master`
   puts "Merge base with origin/master #{merge_base}"
   # only care about modified ruby files since diverge from master
-  changed_files = `git diff --name-only #{merge_base}`.split("\n")
+  #changed_files = `git diff --name-only #{merge_base}`.split("\n")
+
+  # changed files of commit
+  changed_files = `git diff --name-only HEAD HEAD~1`.split("\n")
+  changed_files.delete_if{ |filename| filename[-3..-1] != '.rb' }
+  
 
   if changed_files.length > 0
     puts "Running rubocop on these files: #{changed_files}"

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -84,7 +84,7 @@ def run_rubocop
   errors = nil
   changed_files = JSON.parse(ENV['CHANGED_FILES']).join(" ")
 
-  if changed_files.any?
+  if changed_files.length > 0
     puts "Running rubocop on these files: #{changed_files}"
     Dir.chdir(@GITHUB_WORKSPACE) do
       # only run rubocop on changes files

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -93,7 +93,6 @@ def run_rubocop
     conclusion = 'success'
     count = 0
 
-    puts "Files with errors: #{errors['files'].map{|f| f['path']}.join(", ")}"
     errors['files'].each do |file|
       path = file['path']
       offenses = file['offenses']

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -82,7 +82,10 @@ end
 def run_rubocop
   annotations = []
   errors = nil
-  changed_files = JSON.parse(ENV['CHANGED_FILES']).join(" ")
+  # find out where this diverged from master
+  merge_base = `git merge-base --fork-point master`
+  # only care about modified ruby files since diverge from master
+  changed_files = `git diff --name-only #{merge_base}`.split("\n")
 
   if changed_files.length > 0
     puts "Running rubocop on these files: #{changed_files}"

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -86,10 +86,9 @@ def run_rubocop
   count = 0
 
   # changed files of commit
-  puts `git log -n 2`
   current_commit,previous_commit = `git log -n 2 --format=format:%H`.split("\n")
   changed_files = `git diff --name-only #{current_commit}..#{previous_commit}`.split("\n")
-  puts "Modified files of this commit: \n#{changed_files}\n"
+  puts "Modified files of this commit: \n#{changed_files.join("\n")}\n"
   changed_files.delete_if{ |filename| filename[-3..-1] != '.rb' }
 
   if changed_files.length > 0

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -86,6 +86,7 @@ def run_rubocop
   count = 0
   # find out where this diverged from master
   merge_base = `git merge-base --fork-point origin/master`
+  puts "Merge base with origin/master #{merge_base}"
   # only care about modified ruby files since diverge from master
   changed_files = `git diff --name-only #{merge_base}`.split("\n")
 

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -91,6 +91,7 @@ def run_rubocop
   #changed_files = `git diff --name-only #{merge_base}`.split("\n")
 
   # changed files of commit
+  puts `git log -n 2`
   current_commit,previous_commit = `git log -n 2 --format=format:%H`.split("\n")
   changed_files = `git diff --name-only #{current_commit}..#{previous_commit}`.split("\n")
   changed_files.delete_if{ |filename| filename[-3..-1] != '.rb' }

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -82,8 +82,10 @@ end
 def run_rubocop
   annotations = []
   errors = nil
+  conclusion = 'success'
+  count = 0
   # find out where this diverged from master
-  merge_base = `git merge-base --fork-point master`
+  merge_base = `git merge-base --fork-point origin/master`
   # only care about modified ruby files since diverge from master
   changed_files = `git diff --name-only #{merge_base}`.split("\n")
 
@@ -93,8 +95,6 @@ def run_rubocop
       # only run rubocop on changes files
       errors = JSON.parse(`rubocop --format json #{changed_files}`)
     end
-    conclusion = 'success'
-    count = 0
 
     errors['files'].each do |file|
       path = file['path']
@@ -133,7 +133,6 @@ end
 
 def run
   puts "\nStarting Rubocop..."
-  puts "CHANGED FILES of commit: #{ENV['CHANGED_FILES']}"
 
   id = create_check
   results = run_rubocop

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -88,7 +88,7 @@ def run_rubocop
   conclusion = 'success'
   count = 0
 
-  puts "Files with errors: #{errors['files'].map{|f| f['path'].join(", ")}}"
+  puts "Files with errors: #{errors['files'].map{|f| f['path']}.join(", ")}"
   errors['files'].each do |file|
     path = file['path']
     offenses = file['offenses']

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -49,6 +49,7 @@ def create_check
 end
 
 def update_check(id, conclusion, output)
+  puts "[#{id}] Updating check #{conclusion}"
   body = {
     'name' => @check_name,
     'head_sha' => @GITHUB_SHA,
@@ -87,6 +88,7 @@ def run_rubocop
   conclusion = 'success'
   count = 0
 
+  puts "Files with errors: #{errors['files'].map{|f| f['path'].join(", ")}}"
   errors['files'].each do |file|
     path = file['path']
     offenses = file['offenses']

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -84,18 +84,13 @@ def run_rubocop
   errors = nil
   conclusion = 'success'
   count = 0
-  # find out where this diverged from master
-  merge_base = `git merge-base --fork-point origin/master`
-  puts "Merge base with origin/master #{merge_base}"
-  # only care about modified ruby files since diverge from master
-  #changed_files = `git diff --name-only #{merge_base}`.split("\n")
 
   # changed files of commit
   puts `git log -n 2`
   current_commit,previous_commit = `git log -n 2 --format=format:%H`.split("\n")
   changed_files = `git diff --name-only #{current_commit}..#{previous_commit}`.split("\n")
+  puts "Modified files of this commit: \n#{changed_files}\n"
   changed_files.delete_if{ |filename| filename[-3..-1] != '.rb' }
-  
 
   if changed_files.length > 0
     puts "Running rubocop on these files: #{changed_files}"
@@ -127,7 +122,7 @@ def run_rubocop
       end
     end
   else
-    puts "No new files to run rubocop on, exiting..."
+    puts "No new ruby files to run rubocop on, exiting..."
   end
 
   output = {


### PR DESCRIPTION
Since we were running rubocop on all files, when any highly reproducible error was turned on we would try to create thousands of annotations which would usually result in a 400 response from the github api. This would in turn throw a runtime error. Not much to go with, so this branch adds more logging and removes the runtime error in favor of a specific error being thrown for Github API errors.

This branch assumes a git history of at least the current commit and previous commit are included in the workspace environment. It is needed to determine the changed files of the commit we are running rubocop on.

Further work may be wanted to always pass the changed files of diffing master and the commit, not just the commit as we want this to fail on all commits in a PR if any changed files of the PR throw errors, not just the commit's.