### PR TITLE
Use annotation syntax

### DIFF
--- a/lib/index.rb
+++ b/lib/index.rb
@@ -124,7 +124,7 @@ def run
     if conclusion == 'failure'
       puts output[:summary]
       output['annotations'].each do |annotation|
-        puts "L#{annotation['start_line']}-L#{annotation['end_line']}:#{annotation['message']}"
+        puts "::error file=#{annotation['path']},line=#{annotation['start_line']},endLine=#{annotation['end_line']}::#{annotation['message']}"
       end
       raise 'Rubocop found offenses'
     end


### PR DESCRIPTION
By printing the error messages like this, it should add line annotations on github
![image](https://user-images.githubusercontent.com/810411/162085589-c2102864-f870-46d3-a99c-22ce70e8dba8.png)
